### PR TITLE
Add missing dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "test:jest": "jest"
   },
   "dependencies": {
+    "@octokit/rest": "^17.1.0",
     "@types/yargs": "^15.0.4",
     "hard-rejection": "^2.1.0",
+    "moment": "^2.24.0",
     "yargs": "^15.3.0"
   },
   "devDependencies": {
@@ -30,7 +32,6 @@
     "eslint-plugin-prettier": "^3.1.2",
     "husky": "^4.2.3",
     "jest": "^25.1.0",
-    "moment": "^2.24.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.19.1",
     "release-it": "^13.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -407,7 +407,7 @@
   resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz#eef87a431300f6148c39a7f75f8cfeb218b2547e"
   integrity sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw==
 
-"@octokit/plugin-rest-endpoint-methods@^3.0.0":
+"@octokit/plugin-rest-endpoint-methods@^3.0.0", "@octokit/plugin-rest-endpoint-methods@^3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.3.0.tgz#9b39fb3d90565322fa8a3bfc0063cb7ba2997e34"
   integrity sha512-7Yrf4bXFernGJQgcFKUwikFTBXMSR7OQ3v9kFHux04f9soDrgGUIVMNPHWMYJTEh9jn9KGenq7alIva7Ys/1vA==
@@ -447,6 +447,16 @@
     "@octokit/plugin-paginate-rest" "^2.0.0"
     "@octokit/plugin-request-log" "^1.0.0"
     "@octokit/plugin-rest-endpoint-methods" "^3.0.0"
+
+"@octokit/rest@^17.1.0":
+  version "17.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-17.1.0.tgz#32df64d9dd4855339e9957524a84ced72762a53b"
+  integrity sha512-L5YtpxHZSHZCh2xETbzxz8clBGmcpT+5e78JLZQ+VfuHrHJ1J/r+R2PGwKHwClUEECTeWFMMdAtIik+OCkANBg==
+  dependencies:
+    "@octokit/core" "^2.4.0"
+    "@octokit/plugin-paginate-rest" "^2.0.0"
+    "@octokit/plugin-request-log" "^1.0.0"
+    "@octokit/plugin-rest-endpoint-methods" "^3.3.0"
 
 "@octokit/types@^2.0.0", "@octokit/types@^2.0.1":
   version "2.5.0"


### PR DESCRIPTION
These were missed in the initial implementation, and since we weren't yet using `eslint-plugin-node` we didn't get any warnings/errors about it.

This fixes that :smiley: